### PR TITLE
Associations can be overriden in the serializer

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,19 @@ In this case the PostSerializer will be used to nest the user's posts under the
 You can also include multiple associations by using an array of association
 keys.
 
+#### Overriding association methods
+
+If you want to override any association, you can use:
+
+```ruby
+class UserSerializer::Base
+  attributes :id, :created_at, :updated_at
+
+  def posts
+    object.posts.published
+  end
+end
+```
 
 ## Development
 

--- a/lib/adequate_serializer/base.rb
+++ b/lib/adequate_serializer/base.rb
@@ -81,8 +81,16 @@ module AdequateSerializer
     end
 
     def serialize_association(association_key)
-      associated_objects = object.send(association_key)
+      associated_objects = associated_objects(association_key)
       serialize(associated_objects, root: false)
+    end
+
+    def associated_objects(association_key)
+      if respond_to?(association_key)
+        send(association_key)
+      else
+        object.send(association_key)
+      end
     end
   end
 end

--- a/lib/adequate_serializer/version.rb
+++ b/lib/adequate_serializer/version.rb
@@ -1,3 +1,3 @@
 module AdequateSerializer
-  VERSION = '0.1.0'
+  VERSION = '0.1.1'
 end

--- a/test/associations_test.rb
+++ b/test/associations_test.rb
@@ -46,5 +46,19 @@ module AdequateSerializer
       PersonSerializer.new(peggy, includes: [:colleagues, :superior])
         .associations.must_equal expected
     end
+
+    def test_association_override
+      peggy = Person.new
+      daniel = Person.new(id: 1, name: 'Daniel', occupation: 'Agent')
+      jack = Person.new(id: 4, name: 'Jack', occupation: 'Agent')
+      peggy.colleagues = [daniel, jack]
+      expected = {
+        colleagues: Collection.new([jack], root: false).as_json
+      }
+
+      OverrideAssociationSerializer.new(peggy, includes: :colleagues)
+        .associations
+        .must_equal expected
+    end
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -26,3 +26,13 @@ end
 class PersonSerializer < AdequateSerializer::Base
   attributes :id, :name, :occupation
 end
+
+class OverrideAssociationSerializer < AdequateSerializer::Base
+  attributes :id, :name
+
+  def colleagues
+    object.colleagues.select do |colleague|
+      colleague.read_attribute_for_serialization(:id) > 2
+    end
+  end
+end


### PR DESCRIPTION
Since you can override instance methods in the serializer you should also be able to override associations.

This would be useful to add scopes to the query.
