### PR TITLE
Uses the relation's klass to define the root.

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,11 @@ or use no root at all:
 serialize(@user, root: false)
 ```
 
+It works with a ActiveRecord::Relation or an array. However, if you could end
+up serializing an empty array, you should define a root yourself. Otherwise it
+cannot infer the root key and you will end up with a `nil` key. This
+isn't needed for ActiveRecord::Relations.
+
 ### Attributes
 
 You can specify which attributes of your objects will be serialized in the

--- a/lib/adequate_serializer/collection.rb
+++ b/lib/adequate_serializer/collection.rb
@@ -29,7 +29,17 @@ module AdequateSerializer
     private
 
     def root_name
-      (root || collection.first.class.name.underscore.parameterize.pluralize).to_sym
+      (root || build_root).to_sym
+    end
+
+    def build_root
+      if collection.respond_to?(:klass)
+        klass = collection.klass
+      else
+        klass = collection.first.class
+      end
+
+      klass == NilClass ? 'nil' : klass.name.underscore.parameterize.pluralize
     end
   end
 end

--- a/lib/adequate_serializer/version.rb
+++ b/lib/adequate_serializer/version.rb
@@ -1,3 +1,3 @@
 module AdequateSerializer
-  VERSION = '0.1.1'
+  VERSION = '0.1.2'
 end

--- a/test/root_test.rb
+++ b/test/root_test.rb
@@ -4,17 +4,43 @@ module AdequateSerializer
   class RootTest < Minitest::Spec
     def test_default_root
       peggy = Person.new(id: 1, name: 'Peggy')
+
       TestSerializer.new(peggy).as_json.keys.must_equal [:person]
+    end
+
+    def test_default_root_of_array
+      peggy = Person.new(id: 1, name: 'Peggy')
+
+      Collection.new([peggy]).as_json.keys.must_equal [:people]
+    end
+
+    def test_default_root_of_empty_array
+      Collection.new([]).as_json.keys.must_equal [:nil]
+    end
+
+    def test_default_root_of_relation
+      peggy = Person.new(id: 1, name: 'Peggy')
+      relation = Relation.new(Agent, [peggy])
+
+      Collection.new(relation).as_json.keys.must_equal [:agents]
+    end
+
+    def test_default_root_of_empty_relation
+      relation = Relation.new(Agent, [])
+
+      Collection.new(relation).as_json.keys.must_equal [:agents]
     end
 
     def test_no_root
       peggy = Person.new(id: 1, name: 'Peggy')
+
       TestSerializer.new(peggy, root: false).as_json.keys
         .must_equal [:id, :name]
     end
 
     def test_custom_root
       peggy = Person.new(id: 1, name: 'Peggy')
+
       TestSerializer.new(peggy, root: :agent).as_json.keys.must_equal [:agent]
     end
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -19,6 +19,9 @@ class Person < Model
   attr_accessor :colleagues, :superior
 end
 
+class Agent
+end
+
 class TestSerializer < AdequateSerializer::Base
   attributes :id, :name
 end
@@ -36,3 +39,19 @@ class OverrideAssociationSerializer < AdequateSerializer::Base
     end
   end
 end
+
+class Relation
+  include Enumerable
+
+  attr_reader :klass
+
+  def initialize(klass, values)
+    @klass  = klass
+    @values = values
+  end
+
+  def each(&block)
+    @values.each(&block)
+  end
+end
+


### PR DESCRIPTION
Currently it tries to infer the root of a collection from it's first element. However, if the collection is empty, the first element will be `nil` and the root will be `nil_classes`.

Since it'll be given ActiveRecord::Relations most of the time, it now tries to infer the root from it's `klass` method first. Only if the collection has no `klass` method, it'll use the first element.
